### PR TITLE
Extended the Router class

### DIFF
--- a/instances/Bootstrap.php
+++ b/instances/Bootstrap.php
@@ -133,13 +133,13 @@ class Bootstrap
 	 */
 	public static function invokeController( $controller )
 	{
-		$controller_path = explode( '/', $controller );
+        $c = explode('::',$controller);
+		$controller_path = explode('/',$c[0]);
 
 		$class = '';
-		foreach ( $controller_path as $part )
-		{
-			$class .= ucfirst( $part );
-		}
+        do{
+            $class .= ucfirst( array_shift($controller_path) );
+        }while(!empty($controller_path));
 
 		$class .= 'Controller';
 
@@ -261,13 +261,18 @@ class Bootstrap
 					$controller = $router->getController();
 				}
 			}
-
+            $c = explode('::',$controller);
+            if(!isset($c[1]))
+            {
+                $c[1] = 'build';
+            }
 			// This is the controller to use:
-			$ctrl = self::invokeController( $controller );
+			$ctrl = self::invokeController( implode('::',$c) );
 
 			// Save in params for future references:
 			$ctrl->addParams( array(
-				'controller_route' => $controller,
+				'controller_route' => $c[0],
+                'controller_method'=> $c[1],
 			) );
 
 			// Active/deactive auto-rebuild option:

--- a/instances/CLBootstrap.php
+++ b/instances/CLBootstrap.php
@@ -48,7 +48,13 @@ class CLBootstrap extends Bootstrap
 			self::$language = 'en_US';
 
 			// This is the controller to use:
-			$ctrl = self::invokeController( $controller );
+            $c = explode('::',$controller);
+            if(!isset($c[1]))
+            {
+                $c[1] = 'build';
+            }
+            // This is the controller to use:
+            $ctrl = self::invokeController( implode('::',$c) );
 			$ctrl->build();
 
 			// Debug:

--- a/instances/common/config/router_regex.config.php
+++ b/instances/common/config/router_regex.config.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This config file allows you to define Regex to be used in the router.config.php patterns field.
+ * The default values provided are:
+
+$config['isInteger']        = '([1-9]([0-9]+)?\b)';
+$config['isHex']            = '(0[xX][0-9a-fA-F])';
+$config['isFloat']          = '([-+]?\b[0-9]+(\.[0-9]+)?\b)';
+$config['isBoolean']        = '^([0|1|true|false])';
+$config['isAlphaNumeric']   = '([a-zA-z0-9_\-])';
+$config['isString']         = '([\s\S])';
+
+ */
+
+$config['isInteger']        = '(([1-9]\d?))';
+$config['isHex']            = '(0[xX][0-9a-fA-F])';
+$config['isFloat']          = '([-+]?\b[0-9]+(\.[0-9]+)?\b)';
+$config['isBoolean']        = '^([0|1|true|false])';
+$config['isAlphaNumeric']   = '([a-zA-z0-9_\-])';
+$config['isString']         = '([\s\S])';
+$config['isLocale']         = '([a-zA-Z][a-zA-Z])';             // eg: en
+$config['isLongLocale']     = '([a-z][a-z]_[A-Z][A-Z])';        // eg: en_US

--- a/libs/Sifo/Router.php
+++ b/libs/Sifo/Router.php
@@ -17,176 +17,366 @@
  * limitations under the License.
  *
  */
-
 namespace Sifo;
 
 /**
  * Maps an URL with a controller
  *
- * @author Albert Lombarte
+ * @author Albert Lombarte, Nil Portugués Calderó
  */
 class Router
 {
-
-	static protected $reversal_map = array( );
-	static protected $routes_for_this_language = array();
-	protected $main_controller;
-
-	/**
-	 * Get the used url to access. This info is important to resolve defined 301 redirections.
-	 *
-	 * @return string The used url.
-	 */
-	static public function getUsedUrl()
-	{
-		$server = FilterServer::getInstance();
-
-		$used_url = 'http';
-		if ( $server->getString( "HTTPS" ) == "on" )
-		{
-			$used_url .= "s";
-		}
-		$used_url .= "://";
-
-		if ( $server->getString( 'HTTP_HOST' ) )
-		{
-			$hostname = $server->getString( 'HTTP_HOST' );
-		}
-		else
-		{
-			$hostname = $server->getString( "SERVER_NAME" );
-		}
-
-		if ( $server->getString( 'SERVER_PORT' ) != "80" )
-		{
-			$used_url .= $hostname . ":" . $server->getString( 'SERVER_PORT' ) . $server->getString( "REQUEST_URI" );
-		}
-		else
-		{
-			$used_url .= $hostname . $server->getString( "REQUEST_URI" );
-		}
-
-		return $used_url;
-	}
-
-	/**
-	 * Looks if the path has a known pattern handled by a controller.
-	 *
-	 * @param unknown_type $path
-	 */
-	public function __construct( $path, $instance, $subdomain = false, $language = false, $www_mode = false )
-	{
-		// Look for routes:
-		$routes = Config::getInstance( $instance )->getConfig( 'router' );
-
-		// Failed to parse routes file.
-		if ( !$routes )
-		{
-			throw new Exception_500( "Failed opening router conifiguration file" );
-		}
-
-		if ( $language )
-		{
-			try
-			{
-				self::$routes_for_this_language = Config::getInstance( $instance )->getConfig( 'lang/router_' . $language );
+    protected $main_controller;
+    protected $router_regex = 'router_regex';
+    protected $router_patterns = 'router';
+    static protected $route_vars = array();
+    static protected $routes_for_this_language = array();
+    static protected $reversal_map = array( );
 
 
-				// Translation of URLs:
-				foreach ( self::$routes_for_this_language as $translated_route => $destiny )
-				{
-					if ( isset( $routes[$translated_route] ) && $translated_route != $destiny )
-					{
-						// Replace a translation of the URL by the english entry.
-						$routes[$destiny] = $routes[$translated_route];
+    /**
+     * @param $path
+     * @param $instance
+     * @param bool $subdomain
+     * @param bool $language
+     * @param bool $www_mode
+     */
+    public function __construct($path,$instance,$subdomain = false,$language = false,$www_mode = false)
+    {
+        //load current instance routes.
+        $config = Config::getInstance($instance);
+        $router_patterns = $config->getConfig($this->router_patterns);	// router.config.php
 
-						// Delete the English entry.
-						unset( $routes[$translated_route] );
-					}
+        if ( empty($router_patterns) )
+        {
+            throw new Exception_500( "Failed opening router.config.php configuration file" );
+        }
+
+        $path_parts = explode('/',$path);
+
+        //Check if we're being asked for homepage
+        if(empty($path_parts[0]))
+        {
+            $this->main_controller = $router_patterns['__HOME__'];
+            return $this;
+        }
+
+        //Subdomain can be defined as a controller. Build $path_parts as it wasn't a subdomain for further check.
+        if($subdomain)
+        {
+            $subdomain = array_reverse($this->getSubdomain());
+            do
+            {
+                array_unshift($path_parts,array_shift($subdomain));
+            }while(!empty($subdomain));
+        }
+        $path = implode('/',$path_parts);
+
+        //Check if we'll be using the ROUTE TRANSLATIONS instead of the loaded routes
+        if($language)
+        {
+            $this->languageRouting($router_patterns,$instance,$language);
+        }
+
+        //The routing routine.
+        $not_found = $router_patterns['__NO_ROUTE_FOUND__'];
+        if(!empty($router_patterns[$path_parts[0]]))
+        {
+            //CASE 1: LEGACY COMPATIBILITY - Check if we're being asked for an existing controller
+            if( !is_array($router_patterns[$path_parts[0]]))
+            {
+                $this->main_controller = $router_patterns[$path_parts[0]];
+                return $this;
+            }
+
+            //CASE 2: Check if we're being asked for the controller with no subactions
+            if(!empty($router_patterns[$path_parts[0]]['controller']) && substr_count($path, '/')==0)
+            {
+                $this->main_controller = $router_patterns[$path_parts[0]]['controller'];
+                return $this;
+            }
+
+            //CASE 3: New router system implementation. Look for URL patterns and assign controller (and method if supplied).
+            $router_patterns = $router_patterns[$path_parts[0]];
+            if(!empty($router_patterns['pattern']))
+            {
+                $path = str_replace($path_parts[0].'/','',$path); //remove from the path the matched value.
+
+                $router_patterns['pattern'] = str_replace('/','\/',$router_patterns['pattern']);
+
+                //Replace all placeholders with regex values
+                if(!empty($router_patterns['placeholders']))
+                {
+                    $this->placeholderSetRegExpressions($instance,$router_patterns);
+                }
+
+                //Search url
+                $key = key($router_patterns['pattern']);
+                $elem = array_shift($router_patterns['pattern']);
+                do
+                {
+                    if( preg_match('/^'.$elem.'$/',$path,$vars))
+                    {
+                        //Check if execution will be allowed
+                        $this->validRequestMethod($router_patterns['request_method'][$key]);
+
+                        //Save values
+                        unset($vars[0]);
+                        self::$route_vars = $vars;
+
+                        //Return controller+method
+                        if(strpos($key,'::')===false)
+                        {
+                            $this->main_controller= $router_patterns['controller'];
+                        }
+                        else
+                        {
+                            $this->main_controller = $key;
+                        }
+                        return $this;
+                    }
+
+                    $key = key($router_patterns['pattern']);
+                    $elem = array_shift($router_patterns['pattern']);
+
+                } while(!empty($elem));
+
+            }
+        }
+
+        //The controller cannot be determined by parsing the path or the subdomain
+        if ( ( strlen( $path ) == 0 ) && !( ( $subdomain != "www" && true == $www_mode || strlen( $subdomain ) > 0 && false == $www_mode) ) )
+        {
+            $this->main_controller = $router_patterns['__HOME__'];
+            return $this;
+        }
+        else
+        {
+            if ( $rules_301 = Config::getInstance( $instance )->getConfig( '301_rules' ) )
+            {
+                $used_url = self::getUsedUrl();
+                foreach ( $rules_301 as $regexp => $replacement )
+                {
+                    $destiny = preg_replace( $regexp, $replacement, $used_url, -1, $count );
+
+                    // $count indicates the replaces. If $count gt 0 means that matched.
+                    if ( $count )
+                    {
+                        throw new Exception_301( $destiny );
+                    }
+                }
+            }
+        }
+        $this->main_controller = $not_found;
+        return $this;
+    }
+
+    /**
+     * @param $routes
+     * @param $instance
+     * @param $language
+     */
+    protected function languageRouting(&$routes,$instance,$language)
+    {
+        try
+        {
+            self::$routes_for_this_language = Config::getInstance( $instance )->getConfig( 'lang/router_' . $language );
+
+            //Really important or else URL with patterns won't be translated, as shorter translated URL could interfere.
+            arsort(self::$routes_for_this_language);
+
+            // Translation of URLs:
+            foreach ( self::$routes_for_this_language as $original_route => $translated_route )
+            {
+                //Has  0 slashes, do this
+                if(substr_count($original_route,'/')==0)
+                {
+                    if ( isset( $routes[$original_route] ) && $original_route != $translated_route )
+                    {
+                        // Replace a translation of the URL by the Original entry.
+                        $routes[$translated_route] = $routes[$original_route];
+
+                        // Delete the Original entry.
+                        unset( $routes[$original_route] );
+                    }
+                }
+                //Could have all pattern translated
+                else
+                {
+                    $original = explode('/',$original_route);
+                    if ( !empty($routes[$original[0]]['pattern']) && is_array($routes[$original[0]]['pattern']) )
+                    {
+                        //Get original pattern value
+                        $pattern = explode('/',$original_route);
+                        array_shift($pattern);
+                        $pattern = implode('/',$pattern);
+
+                        $key = array_search($pattern,$routes[$original[0]]['pattern']);
+                        if($key)
+                        {
+                            //Get pattern translation
+                            $translation = explode('/',$translated_route);
+                            array_shift($translation);
+                            $translation = implode('/',$translation);
+
+                            // Replace a translation of the URL by the Original entry.
+                            $routes[$original[0]]['pattern'][$key] = $translation;
+                        }
+                    }
+                }
+                // Create a mapping table with the association translated => original
+                self::$reversal_map[$translated_route] = $translated_route;
+            }
+        }
+        catch ( Exception_Configuration $e )
+        {
+            // trigger_error( "Failed to load url config profile for language '$language'" );
+        }
+    }
 
 
-					// Create a mapping table with the association translated => original
-					self::$reversal_map[$destiny] = $translated_route;
-				}
-			}
-			catch ( Exception_Configuration $e )
-			{
-				// trigger_error( "Failed to load url config profile for language '$language'" );
-			}
-		}
+    /**
+     * Returns an array with the subdomain values
+     *
+     * @return array
+     */
+    protected function getSubdomain()
+    {
+        $url = $this->getUsedUrl();
+        $parsedUrl = parse_url($url);
+        $host = explode('.', $parsedUrl['host']);
+        return array_slice($host, 0, count($host) - 2 );
+    }
 
-		foreach ( $routes as $route => $controller )
-		{
-			// The subdomain can define the controller to use.
-			if ( $subdomain == $route )
-			{
-				$this->main_controller = $controller;
-				return;
-			}
-			// No valid subdomain for controller, use path to define controller instead:
-			elseif ( $path == $route )
-			{
-				$this->main_controller = $controller;
-				return;
-			}
-		}
+    /**
+     * Checks if a controller has specified being restricted to be requested by a subset of HTTP request methods.
+     *
+     * @param $config
+     * @return bool
+     * @throws Exception_404
+     */
+    protected function validRequestMethod(&$config)
+    {
+        // Validate Controller REQUEST_METHOD. If no REQUEST_METHOD is set, keep going.
+        if( isset($config) )
+        {
+            if(!in_array( FilterServer::getInstance()->getString('REQUEST_METHOD'),array_map("strtoupper",$config)))
+            {
+                throw new Exception_404();
+            }
+        }
+    }
 
-		// The controller cannot be determined by parsing the path or the subdomain, is a home?
-		if ( !isset( $this->main_controller ) )
-		{
-			if ( ( strlen( $path ) == 0 ) && !( ( $subdomain != "www" && true == $www_mode || strlen( $subdomain ) > 0 && false == $www_mode) ) )
-			{
-				$this->main_controller = $routes['__HOME__'];
-			}
-			else
-			{
-				if ( $rules_301 = Config::getInstance( $instance )->getConfig( '301_rules' ) )
-				{
-					$used_url = self::getUsedUrl();
-					foreach ( $rules_301 as $regexp => $replacement )
-					{
-						$destiny = preg_replace( $regexp, $replacement, $used_url, -1, $count );
+    /**
+     * @param $instance
+     * @param $router_patterns
+     * @throws Exception_500
+     */
+    protected function placeholderSetRegExpressions($instance,&$router_patterns)
+    {
+        $config = Config::getInstance($instance);
+        $regex = $config->getConfig($this->router_regex);	// router_regex.config.php
 
-						// $count indicates the replaces. If $count gt 0 means that was matchs.
-						if ( $count )
-						{
-							throw new Exception_301( $destiny );
-						}
-					}
-				}
-				// No route found, use default.
-				$this->main_controller = $routes['__NO_ROUTE_FOUND__'];
-			}
-		}
-	}
+        if ( empty($regex) )
+        {
+            throw new Exception_500( "Failed opening router_regex.config.php configuration file" );
+        }
 
-	public function getController()
-	{
-		return $this->main_controller;
-	}
+        //Replace placeholders for its regex equivalents
+        $key = key($router_patterns['placeholders']);
+        $elem = array_shift($router_patterns['placeholders']);
+        do{
+            //replace placeholder for regex
+            $router_patterns['pattern'] = str_replace(array_values($elem),$regex[$key],$router_patterns['pattern']);
 
-	/**
-	 * Returns the key associated to a translated route. Or same string if no reversal found.
-	 *
-	 * For instance, if you pass 'ayuda' should return 'help'.
-	 *
-	 * @param string $translated_route
-	 * @return string
-	 */
-	static public function getReversalRoute( $translated_route )
-	{
-		if ( isset( self::$reversal_map[$translated_route] ) )
-		{
-			// The path has translation:
-			return self::$reversal_map[$translated_route];
-		}
+            //next item
+            $key = key($router_patterns['placeholders']);
+            $elem = array_shift($router_patterns['placeholders']);
+        } while( !empty($elem) );
 
-		if ( !isset( self::$routes_for_this_language[ $translated_route ] )  )
-		{
-			// There are not available translation for this route.
-			return $translated_route;
-		}
+        //Replaces all unmatched {} keys with (.+)
+        if(preg_match_all('/{([^}]*)}/',implode(',',$router_patterns['pattern']),$vars))
+        {
+            $router_patterns['pattern'] = str_replace($vars[0],'(.+)',$router_patterns['pattern']);
+        }
+    }
 
-		return false;
-	}
+
+    /**
+     * @return array
+     */
+    public function getControllerVars()
+    {
+        return self::$route_vars;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getController()
+    {
+        return $this->main_controller;
+    }
+
+
+    /**
+     * Get the used url to access. This info is important to resolve defined 301 redirections.
+     *
+     * @return string The used url.
+     */
+    static public function getUsedUrl()
+    {
+        $server = FilterServer::getInstance();
+
+        $used_url = 'http';
+        if ( $server->getString( "HTTPS" ) == "on" )
+        {
+            $used_url .= "s";
+        }
+        $used_url .= "://";
+
+        if ( $server->getString( 'HTTP_HOST' ) )
+        {
+            $hostname = $server->getString( 'HTTP_HOST' );
+        }
+        else
+        {
+            $hostname = $server->getString( "SERVER_NAME" );
+        }
+
+        if ( $server->getString( 'SERVER_PORT' ) != "80" )
+        {
+            $used_url .= $hostname . ":" . $server->getString( 'SERVER_PORT' ) . $server->getString( "REQUEST_URI" );
+        }
+        else
+        {
+            $used_url .= $hostname . $server->getString( "REQUEST_URI" );
+        }
+
+        return $used_url;
+    }
+
+    /**
+     * Returns the key associated to a translated route. Or same string if no reversal found.
+     *
+     * For instance, if you pass 'ayuda' should return 'help'.
+     *
+     * @param string $translated_route
+     * @return string
+     */
+    static public function getReversalRoute( $translated_route )
+    {
+        if ( isset( self::$reversal_map[$translated_route] ) )
+        {
+            // The path has translation:
+            return self::$reversal_map[$translated_route];
+        }
+
+        if ( !isset( self::$routes_for_this_language[ $translated_route ] )  )
+        {
+            // There are not available translation for this route.
+            return $translated_route;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
## Explanation

Extended the Router class adds new functionalities while keeping the global performance impact (very) low. Modified files to allow this new feature: Router.php, Controller.php Bootstrap.php and CLBootstrap.php.

This new method uses half compiled URLs. Replacement of the regex is done wisely using str_replace avoiding innecessary loops that would add up time.  

For all loops, do_while is being used to shave off some time. (Note: I offer myself to rewrite most loops to do whiles to gain performance.)

It keeps 100% compatibility with the current URL set up, translating URLs and using controllers as domains and even using translations in domain set up. Putting it simple, it is backwards compatible.
## Example

Usage of the new routing system in router.config.php

``` php
//...
$config['__NO_ROUTE_FOUND__'] = 'static/index';
$config['__HOME__'] = 'home/index';

//Old style, still works :)
$config['hello_world'] = 'home/index';

//New way
$config['admin']=array
(
    'controller' => 'admin/index', //default Controller for /admin
    'pattern' => array
    (
        //New controllers under the admin route
        // <controller_path>::<controller_method> => 'url pattern'
        //If no <controller_method> is supplied, build is used
        'admin/blog/index'         => 'blog',
        'admin/blog/post::create'  => 'blog/post/create',
        'admin/blog/post::update'  => 'blog/post/{id}/update',
        'admin/blog/post::delete'  => 'blog/post/{id}/delete',

        //USER ROUTING
        'admin/users/index'         => 'users',
        'admin/users/index::create' => 'users/create',
        'admin/users/index::update' => 'users/{uid}/update',
        'admin/users/index::delete' => 'users/{uid}/delete',

        //As many more as you like
    ),
    //Placeholder array keys are defined in router_regex.config.php
    'placeholders' => array
    (
        'isInteger' => array('{uid}','{id}')
    ),
    'request_method' => array
    (
        //Key value must match the one in the pattern.
        'admin/users/index::create' => array('GET','POST')
    )
);
```

Required new config file: router_regex.config.php allowing different regex. Here's the default set I've come up with.

``` php

$config['isInteger']        = '(([1-9]\d?))';
$config['isHex']            = '(0[xX][0-9a-fA-F])';
$config['isFloat']          = '([-+]?\b[0-9]+(\.[0-9]+)?\b)';
$config['isBoolean']        = '^([0|1|true|false])';
$config['isAlphaNumeric']   = '([a-zA-z0-9_\-])';
$config['isString']         = '([\s\S])';
$config['isLocale']         = '([a-zA-Z][a-zA-Z])';             // eg: en
$config['isLongLocale']     = '([a-z][a-z]_[A-Z][A-Z])';        // eg: en_US
```
