### PR TITLE
Added check before executing a class method other than build.

### DIFF
--- a/libs/Sifo/Controller.php
+++ b/libs/Sifo/Controller.php
@@ -635,7 +635,7 @@ abstract class Controller
 	{
             	$vars = Router::getControllerVars();
 
-            	if( isset( $this->params['controller_method'] ) ) {
+            	if( isset( $this->params['controller_method'] ) && method_exists( $this, $this->params['controller_method'] ) ) {
                             $method = $this->params['controller_method'];
            	} else {
                             $method = 'build';


### PR DESCRIPTION
Line 638: method_exists($this,$this->params['controller_method'])) is necessary in order to avoid loading inexistant methods from the current class instance, and moreover, any class instances invoked when loading them as a module (using $this->addModule()).

Note, this example assumes we're using the new router style, as it is the only way to break the controller. In this example, we want to run the update method.

``` php
class HomeIndexController extends \Sifo\Controller
{
   function update($id)
   {
     //...
     $this->addModule('flash_message','HomeFlashMessage');
     //...
   }
}
```

and the module...

``` php
class HomeFlashMessageController extends \Sifo\Controller
{
   function build()
   {
     //...
   }
}
```

$this->addModule will invoke HomeFlashMessageController. If the current \Sifo\Controller class is not patched, the current code will try to run the "update" method on HomeFlashMessageController, resulting in an error. This patch defaults to build() as the update() method doesn't exist.
