### PR TITLE
Updated url of contributors list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         },
         {
             "name": "SIFO PHP Contributors",
-            "homepage": "https://github.com/sifophp?tab=members"
+            "homepage": "http://sifo.me/about"
         }
     ],
     "require": {


### PR DESCRIPTION
Changed the url from github sifophp organization members to the sifo about page
