### PR TITLE
Fix Registry::invalidate method to invalidate a key that contains a NULL value

### DIFF
--- a/src/Sifo/Registry.php
+++ b/src/Sifo/Registry.php
@@ -99,7 +99,7 @@ class Registry
 	 */
 	public static function invalidate( $key )
 	{
-		if ( isset( self::$storage[$key] ) )
+		if ( self::keyExists($key) )
 		{
 			unset( self::$storage[$key] );
 		}


### PR DESCRIPTION
This PR contains a fix in the `Registry` component due to it does not take into account a key with a NULL value:

## Expected behaviour

```php
Registry::set('test', null);
Registry::get('test'); // Returns NULL;
Registry::keyExists('test'); // Returns true

Registry::invalidate('test');

Registry::get('test'); // Return false <---
Registry::keyExists('test'); // Returns false <---

```

## Actual behaviour

```php
Registry::set('test', null);
Registry::get('test'); // Returns NULL;
Registry::keyExists('test'); // Returns true

Registry::invalidate('test');

Registry::get('test'); // Return null <---
Registry::keyExists('test'); // Returns true <---

```