### PR TITLE
MDI-1439: set addo cache dir default as if safe mode disabled

### DIFF
--- a/src/adodb5/adodb.inc.php
+++ b/src/adodb5/adodb.inc.php
@@ -278,8 +278,7 @@
 		function getdirname($hash)
 		{
 		global $ADODB_CACHE_DIR;
-			if (!isset($this->notSafeMode)) $this->notSafeMode = !ini_get('safe_mode');
-			return ($this->notSafeMode) ? $ADODB_CACHE_DIR.'/'.substr($hash,0,2) : $ADODB_CACHE_DIR;
+			return $ADODB_CACHE_DIR.'/'.substr($hash,0,2);
 		}
 
 		// create temp directories


### PR DESCRIPTION
WARNING: INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4
