### PR TITLE
 AD-231 Add secure and http_only parameters support for cookies

### DIFF
--- a/src/Sifo/Cookie.php
+++ b/src/Sifo/Cookie.php
@@ -49,7 +49,7 @@ class Cookie
 	{
 		self::$cookies = array( );
 		// Take domain from configuration to allow multiple subdomain compatibility with cookies.
-		self::$domain = static::domain();
+		self::$domain = Domains::getInstance()->getDomain();
 		self::$path = '/';
 	}
 
@@ -151,10 +151,5 @@ class Cookie
         }
 
         return setcookie( $name, $value, $options );
-    }
-
-    static protected function domain()
-    {
-        return Domains::getInstance()->getDomain();
     }
 }

--- a/src/Sifo/Cookie.php
+++ b/src/Sifo/Cookie.php
@@ -49,22 +49,21 @@ class Cookie
 	{
 		self::$cookies = array( );
 		// Take domain from configuration to allow multiple subdomain compatibility with cookies.
-		self::$domain = Domains::getInstance()->getDomain();
+		self::$domain = static::domain();
 		self::$path = '/';
 	}
 
-	static public function set( $name, $value, $days = 14, $domain = false, $secure = false, $http_only = false )
+	static public function set( $name, $value, $days = 14, $domain = false, $secure = false, $httpOnly = false )
 	{
-
 		$domain ?: self::_initDomain();
 
 		if ( 0 == $days )
 		{
-			$result = setcookie( $name, $value, 0, self::$path, self::$domain, $secure, $http_only );
+			$result = static::setCookie( $name, $value, 0, self::$path, self::$domain, $secure, $httpOnly );
 		}
 		else
 		{
-			$result = setcookie( $name, $value, time() + ( 86400 * $days ), self::$path, self::$domain, $secure, $http_only );
+			$result = static::setCookie( $name, $value, time() + ( 86400 * $days ), self::$path, self::$domain, $secure, $httpOnly );
 		}
 		if ( !$result )
 		{
@@ -81,7 +80,7 @@ class Cookie
 	static public function delete( $name )
 	{
 		self::_initDomain();
-		$result = setcookie( $name, '', time() - 3600, self::$path, self::$domain );
+		$result = static::setCookie( $name, '', 0, self::$path, self::$domain);
 		if ( !$result )
 		{
 			trigger_error( "COOKIE DELETE FAIL: Tried to delete '$name' but failed." );
@@ -140,4 +139,14 @@ class Cookie
 
 		return false;
 	}
+
+    static protected function setCookie(string $name, $value = "", $expires_or_options = 0, $path = "", $domain = "", $secure = false, $httponly = false): bool
+    {
+        return setcookie( $name, $value, $expires_or_options, $path, $domain, $secure, $httponly );
+    }
+
+    static protected function domain()
+    {
+        return Domains::getInstance()->getDomain();
+    }
 }

--- a/src/Sifo/Cookie.php
+++ b/src/Sifo/Cookie.php
@@ -53,18 +53,18 @@ class Cookie
 		self::$path = '/';
 	}
 
-	static public function set( $name, $value, $days = 14, $domain = false )
+	static public function set( $name, $value, $days = 14, $domain = false, $secure = false, $http_only = false )
 	{
 
 		$domain ?: self::_initDomain();
 
 		if ( 0 == $days )
 		{
-			$result = setcookie( $name, $value, 0, self::$path, self::$domain );
+			$result = setcookie( $name, $value, 0, self::$path, self::$domain, $secure, $http_only );
 		}
 		else
 		{
-			$result = setcookie( $name, $value, time() + ( 86400 * $days ), self::$path, self::$domain );
+			$result = setcookie( $name, $value, time() + ( 86400 * $days ), self::$path, self::$domain, $secure, $http_only );
 		}
 		if ( !$result )
 		{

--- a/src/Sifo/Cookie.php
+++ b/src/Sifo/Cookie.php
@@ -76,7 +76,7 @@ class Cookie
 	static public function delete( $name )
 	{
 		self::_initDomain();
-		$result = static::setCookie( $name, '', 0, self::$path, self::$domain);
+		$result = static::setCookie( $name, '', time() - 3600, self::$path, self::$domain);
 		if ( !$result )
 		{
 			trigger_error( "COOKIE DELETE FAIL: Tried to delete '$name' but failed." );

--- a/src/Sifo/Cookie.php
+++ b/src/Sifo/Cookie.php
@@ -57,14 +57,12 @@ class Cookie
 	{
 		$domain ?: self::_initDomain();
 
-		if ( 0 == $days )
-		{
-			$result = static::setCookie( $name, $value, 0, self::$path, self::$domain, $secure, $httpOnly );
-		}
-		else
-		{
-			$result = static::setCookie( $name, $value, time() + ( 86400 * $days ), self::$path, self::$domain, $secure, $httpOnly );
-		}
+        $expires = 0 == $days
+            ? 0
+            : time() + ( 86400 * $days );
+
+        $result = static::setCookie( $name, $value, $expires, self::$path, self::$domain, $secure, $httpOnly );
+
 		if ( !$result )
 		{
 			trigger_error( "COOKIE WRITE FAIL: Tried to write '$name' with value '$value' but failed." );

--- a/src/Sifo/Cookie.php
+++ b/src/Sifo/Cookie.php
@@ -136,10 +136,10 @@ class Cookie
 		return false;
 	}
 
-    static protected function setCookie(string $name, $value = "", $expires_or_options = 0, $path = "", $domain = "", $secure = false, $httponly = false, string $samesite = null): bool
+    static protected function setCookie(string $name, $value = "", $expires = 0, $path = "", $domain = "", $secure = false, $httponly = false, string $samesite = null): bool
     {
         $options = [
-            'expires' => $expires_or_options,
+            'expires' => $expires,
             'path' => $path,
             'domain' => $domain,
             'secure' => $secure,

--- a/src/Sifo/Cookie.php
+++ b/src/Sifo/Cookie.php
@@ -53,15 +53,13 @@ class Cookie
 		self::$path = '/';
 	}
 
-	static public function set( $name, $value, $days = 14, $domain = false, $secure = false, $httpOnly = false )
+	static public function set( $name, $value, $days = 14, $domain = false, $secure = false, $httpOnly = false, string $samesite = null )
 	{
 		$domain ?: self::_initDomain();
 
-        $expires = 0 == $days
-            ? 0
-            : time() + ( 86400 * $days );
+		$expires = 0 == $days ? 0 : time() + ( 86400 * $days );
 
-        $result = static::setCookie( $name, $value, $expires, self::$path, self::$domain, $secure, $httpOnly );
+		$result = static::setCookie( $name, $value, $expires, self::$path, self::$domain, $secure, $httpOnly, $samesite );
 
 		if ( !$result )
 		{
@@ -138,9 +136,21 @@ class Cookie
 		return false;
 	}
 
-    static protected function setCookie(string $name, $value = "", $expires_or_options = 0, $path = "", $domain = "", $secure = false, $httponly = false): bool
+    static protected function setCookie(string $name, $value = "", $expires_or_options = 0, $path = "", $domain = "", $secure = false, $httponly = false, string $samesite = null): bool
     {
-        return setcookie( $name, $value, $expires_or_options, $path, $domain, $secure, $httponly );
+        $options = [
+            'expires' => $expires_or_options,
+            'path' => $path,
+            'domain' => $domain,
+            'secure' => $secure,
+            'httponly' => $httponly,
+        ];
+
+        if ( $samesite !== null) {
+            $options['samesite'] = $samesite;
+        }
+
+        return setcookie( $name, $value, $options );
     }
 
     static protected function domain()

--- a/test/Sifo/CookieTest.php
+++ b/test/Sifo/CookieTest.php
@@ -21,7 +21,7 @@ class CookieTest extends TestCase
 
         $this->assertEquals(
             $defaultExpiration,
-            TestCookie::getExpiresOrOptions($cookieName),
+            TestCookie::getExpires($cookieName),
             "Expires doesn't match with expected."
         );
         $this->assertSame(
@@ -45,7 +45,7 @@ class CookieTest extends TestCase
 
         TestCookie::set($cookieName, 'oreo', 0);
 
-        $this->assertSame(0, TestCookie::getExpiresOrOptions($cookieName));
+        $this->assertSame(0, TestCookie::getExpires($cookieName));
     }
 
     public function testCookieIsSetWithCustomParameters(): void
@@ -58,7 +58,7 @@ class CookieTest extends TestCase
 
         $this->assertEquals(
             $defaultExpiration,
-            TestCookie::getExpiresOrOptions($cookieName),
+            TestCookie::getExpires($cookieName),
             "Expires doesn't match with expected."
         );
         $this->assertSame(

--- a/test/Sifo/CookieTest.php
+++ b/test/Sifo/CookieTest.php
@@ -34,6 +34,7 @@ class CookieTest extends TestCase
             TestCookie::getPath($cookieName),
             "Path doesn't match with expected."
         );
+        $this->assertNull(TestCookie::getSameSite($cookieName));
         $this->assertFalse(TestCookie::isSecure($cookieName));
         $this->assertFalse(TestCookie::isHttpOnly($cookieName));
     }
@@ -53,7 +54,7 @@ class CookieTest extends TestCase
         $expirationDays = 7;
         $defaultExpiration = time() + ( 86400 * $expirationDays );
 
-        TestCookie::set($cookieName, 'chips_ahoy', $expirationDays, false, true, true);
+        TestCookie::set($cookieName, 'chips_ahoy', $expirationDays, false, true, true, 'Lax');
 
         $this->assertEquals(
             $defaultExpiration,
@@ -69,6 +70,11 @@ class CookieTest extends TestCase
             '/',
             TestCookie::getPath($cookieName),
             "Path doesn't match with expected."
+        );
+        $this->assertSame(
+            'Lax',
+            TestCookie::getSameSite($cookieName),
+            "Same site doesn't match with expected."
         );
         $this->assertTrue(TestCookie::isSecure($cookieName));
         $this->assertTrue(TestCookie::isHttpOnly($cookieName));

--- a/test/Sifo/CookieTest.php
+++ b/test/Sifo/CookieTest.php
@@ -25,7 +25,7 @@ class CookieTest extends TestCase
             "Expires doesn't match with expected."
         );
         $this->assertSame(
-            'example',
+            'sifo.local',
             TestCookie::getDomain($cookieName),
             "Domain doesn't match with expected."
         );
@@ -62,7 +62,7 @@ class CookieTest extends TestCase
             "Expires doesn't match with expected."
         );
         $this->assertSame(
-            'example',
+            'sifo.local',
             TestCookie::getDomain($cookieName),
             "Domain doesn't match with expected."
         );

--- a/test/Sifo/CookieTest.php
+++ b/test/Sifo/CookieTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Sifo\Test\Sifo;
+
+use PHPUnit\Framework\TestCase;
+use Sifo\FilterCookieRuntime;
+
+class CookieTest extends TestCase
+{
+    protected function setUp()
+    {
+        TestCookie::clearCookies();
+    }
+
+    public function testCookieIsSetWithExpectedDefaults(): void
+    {
+        $cookieName = 'test_cookie';
+        $defaultExpiration = time() + ( 86400 * 14 );
+
+        TestCookie::set($cookieName, 'oreo');
+
+        $this->assertEquals(
+            $defaultExpiration,
+            TestCookie::getExpiresOrOptions($cookieName),
+            "Expires doesn't match with expected."
+        );
+        $this->assertSame(
+            'example',
+            TestCookie::getDomain($cookieName),
+            "Domain doesn't match with expected."
+        );
+        $this->assertSame(
+            '/',
+            TestCookie::getPath($cookieName),
+            "Path doesn't match with expected."
+        );
+        $this->assertFalse(TestCookie::isSecure($cookieName));
+        $this->assertFalse(TestCookie::isHttpOnly($cookieName));
+    }
+
+    public function testCookieCanBeSetWithoutExpiration(): void
+    {
+        $cookieName = 'test_cookie';
+
+        TestCookie::set($cookieName, 'oreo', 0);
+
+        $this->assertSame(0, TestCookie::getExpiresOrOptions($cookieName));
+    }
+
+    public function testCookieIsSetWithCustomParameters(): void
+    {
+        $cookieName = 'test_cookie';
+        $expirationDays = 7;
+        $defaultExpiration = time() + ( 86400 * $expirationDays );
+
+        TestCookie::set($cookieName, 'chips_ahoy', $expirationDays, false, true, true);
+
+        $this->assertEquals(
+            $defaultExpiration,
+            TestCookie::getExpiresOrOptions($cookieName),
+            "Expires doesn't match with expected."
+        );
+        $this->assertSame(
+            'example',
+            TestCookie::getDomain($cookieName),
+            "Domain doesn't match with expected."
+        );
+        $this->assertSame(
+            '/',
+            TestCookie::getPath($cookieName),
+            "Path doesn't match with expected."
+        );
+        $this->assertTrue(TestCookie::isSecure($cookieName));
+        $this->assertTrue(TestCookie::isHttpOnly($cookieName));
+    }
+
+    public function testCookieValueIsStoredInFilterCookie(): void
+    {
+        $cookieName = 'test_cookie';
+
+        TestCookie::set($cookieName, 'oreo');
+
+        $this->assertSame(
+            'oreo',
+            FilterCookieRuntime::getInstance()->getString('test_cookie')
+        );
+    }
+
+    public function testCookieValueIsDeletedFromFilterCookie(): void
+    {
+        $cookieName = 'test_cookie';
+
+        TestCookie::set($cookieName, 'oreo');
+        TestCookie::delete($cookieName);
+
+        $this->assertTrue(FilterCookieRuntime::getInstance()->isEmpty('test_cookie'));
+    }
+}

--- a/test/Sifo/TestCookie.php
+++ b/test/Sifo/TestCookie.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Sifo\Test\Sifo;
+
+use InvalidArgumentException;
+use Sifo\Cookie;
+use Sifo\Domains;
+
+class TestCookie extends Cookie
+{
+    protected static function setCookie(
+        string $name,
+        $value = "",
+        $expires_or_options = 0,
+        $path = "",
+        $domain = "",
+        $secure = false,
+        $httponly = false
+    ): bool {
+        if ($value === "") {
+            unset(self::$cookies[$name]);
+
+            return true;
+        }
+
+        self::$cookies[$name] = [
+            'value' => $value,
+            'expires_or_options' => $expires_or_options,
+            'path' => $path,
+            'domain' => $domain,
+            'secure' => $secure,
+            'httponly' => $httponly
+        ];
+
+
+        return true;
+    }
+
+    public static function getCookieParam(string $name, string $param)
+    {
+        if (!array_key_exists($name, self::$cookies)) {
+            throw new InvalidArgumentException("Cookie of name $name is not set.");
+        }
+
+        if (!array_key_exists($param, self::$cookies[$name] ?? [])) {
+            throw new InvalidArgumentException("Param $param does not exist in a cookie.");
+        }
+
+        return self::$cookies[$name][$param];
+    }
+
+    public static function getValue(string $name): string
+    {
+        return (string) self::getCookieParam($name, 'value');
+    }
+
+    public static function getExpiresOrOptions(string $name)
+    {
+        return self::getCookieParam($name, 'expires_or_options');
+    }
+
+    public static function getPath(string $name): string
+    {
+        return (string) self::getCookieParam($name, 'path');
+    }
+
+    public static function getDomain(string $name): string
+    {
+        return (string) self::getCookieParam($name, 'domain');
+    }
+
+    public static function isSecure(string $name): bool
+    {
+        return (bool) self::getCookieParam($name, 'secure');
+    }
+
+    public static function isHttpOnly(string $name): bool
+    {
+        return (bool) self::getCookieParam($name, 'httponly');
+    }
+
+    public static function clearCookies(): void
+    {
+        self::$cookies = [];
+    }
+
+    protected static function domain()
+    {
+        return 'example';
+    }
+}

--- a/test/Sifo/TestCookie.php
+++ b/test/Sifo/TestCookie.php
@@ -11,7 +11,7 @@ class TestCookie extends Cookie
     protected static function setCookie(
         string $name,
         $value = "",
-        $expires_or_options = 0,
+        $expires = 0,
         $path = "",
         $domain = "",
         $secure = false,
@@ -26,7 +26,7 @@ class TestCookie extends Cookie
 
         self::$cookies[$name] = [
             'value' => $value,
-            'expires_or_options' => $expires_or_options,
+            'expires' => $expires,
             'path' => $path,
             'domain' => $domain,
             'secure' => $secure,
@@ -55,9 +55,9 @@ class TestCookie extends Cookie
         return (string) self::getCookieParam($name, 'value');
     }
 
-    public static function getExpiresOrOptions(string $name)
+    public static function getExpires(string $name)
     {
-        return self::getCookieParam($name, 'expires_or_options');
+        return self::getCookieParam($name, 'expires');
     }
 
     public static function getPath(string $name): string

--- a/test/Sifo/TestCookie.php
+++ b/test/Sifo/TestCookie.php
@@ -15,7 +15,8 @@ class TestCookie extends Cookie
         $path = "",
         $domain = "",
         $secure = false,
-        $httponly = false
+        $httponly = false,
+        string $samesite = null
     ): bool {
         if ($value === "") {
             unset(self::$cookies[$name]);
@@ -29,9 +30,9 @@ class TestCookie extends Cookie
             'path' => $path,
             'domain' => $domain,
             'secure' => $secure,
-            'httponly' => $httponly
+            'httponly' => $httponly,
+            'samesite' => $samesite,
         ];
-
 
         return true;
     }
@@ -43,7 +44,7 @@ class TestCookie extends Cookie
         }
 
         if (!array_key_exists($param, self::$cookies[$name] ?? [])) {
-            throw new InvalidArgumentException("Param $param does not exist in a cookie.");
+            return null;
         }
 
         return self::$cookies[$name][$param];
@@ -77,6 +78,11 @@ class TestCookie extends Cookie
     public static function isHttpOnly(string $name): bool
     {
         return (bool) self::getCookieParam($name, 'httponly');
+    }
+
+    public static function getSameSite(string $name): ?string
+    {
+        return self::getCookieParam($name, 'samesite');
     }
 
     public static function clearCookies(): void

--- a/test/Sifo/TestCookie.php
+++ b/test/Sifo/TestCookie.php
@@ -89,9 +89,4 @@ class TestCookie extends Cookie
     {
         self::$cookies = [];
     }
-
-    protected static function domain()
-    {
-        return 'example';
-    }
 }


### PR DESCRIPTION
* Introduce new parameters to allow secure and http_only parameters usage.
* Defaulted both to false `$secure = false, $http_only = false` so current behaviour is preserved.