### PR TITLE
MDI-2027: remove deprecated query fixer in database class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,26 +25,26 @@
     }
   ],
   "require": {
-    "php": ">=7.2",
+    "php": "^7.3|^7.4",
     "adodb/adodb-php": "^5.21",
     "geoip/geoip": "^1.17",
     "neutron/sphinxsearch-api": "^2.0",
     "phpmailer/phpmailer": "^6.5",
     "psr/container": "^1.0",
-    "smarty/smarty": "^3.1.43",
+    "smarty/smarty": "^3.1.45",
     "symfony/dotenv": "^3.3.1|^4.3.1|^5.0.1",
     "symfony/yaml": "^3.2|^4.3.1|^5.0.1",
     "tpyo/amazon-s3-php-class": "^0.5",
     "twig/extensions": "^1.4",
     "twig/twig": "^2.15",
-    "weotch/phpthumb": "^1.0"
+    "weotch/phpthumb": "^1.0.5"
   },
   "require-dev": {
     "adlawson/vfs": "^0.12.1",
     "mikey179/vfsstream": "^1.6",
     "phpcompatibility/php-compatibility": "^9.3",
-    "phpunit/phpunit": "^5.7",
-    "sifophp/sifo-common-instance": "*",
+    "phpunit/phpunit": "^6.5",
+    "sifophp/sifo-common-instance": "@dev",
     "sifophp/sifoweb": "@dev",
     "squizlabs/php_codesniffer": "^3.6",
     "symfony/var-dumper": "^5.4"

--- a/src/Sifo/Database.php
+++ b/src/Sifo/Database.php
@@ -226,7 +226,7 @@ class Database
 		try
 		{
             if (isset($args[1]) && is_array($args[1])) {
-                $args[1] = $this->fixQueryParamsForMultidimensionalArray($args[0], $args[1]);
+                $args[1] = $this->parseQueryParamsForMultidimensionalArray($args[1]);
                 if (count($args[1]) === 0) {
                     unset($args[1]);
                 }
@@ -275,36 +275,13 @@ class Database
 		return $answer;
 	}
 
-    private function fixQueryParamsForMultidimensionalArray(string $query, array $params): array
+    private function parseQueryParamsForMultidimensionalArray(array $params): array
     {
         if (false === isset($params[0])) {
             return $params;
         }
 
-        $split_query = explode('?', $query);
-        $bind_count = count($split_query) - 1;
-        $params = is_array($params[0]) ? $params[0] : $params;
-        $params_count = count($params);
-
-        if ($params_count > $bind_count) {
-            $template = <<<EOF
-Adding more parameters than query binds will be not allowed starting from 3.1.0 version. 
-
-Query: %s
-Params: %s
-Bindings: %s
-
-EOF;
-
-            trigger_error(
-                sprintf($template, $query, var_export($params, true), $bind_count),
-                \E_USER_DEPRECATED
-            );
-
-            array_splice($params, -(count($params) - $bind_count));
-        }
-
-        return $params;
+        return is_array($params[0]) ? $params[0] : $params;
     }
 
 	function __get( $property )

--- a/test/CryptTest.php
+++ b/test/CryptTest.php
@@ -2,9 +2,10 @@
 
 namespace Sifo\Test;
 
+use PHPUnit\Framework\TestCase;
 use Sifo\Crypt;
 
-class CryptTest extends \PHPUnit_Framework_TestCase
+class CryptTest extends TestCase
 {
     /** @var string */
     private $text;


### PR DESCRIPTION
Required change to update the next minor release. 
* Drop PHP 7.2 support
* Fix PHP support to actually tested versions ^7.3 and ^7.4